### PR TITLE
Project sort

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -5,7 +5,7 @@ class ProjectsController < ApplicationController
   # GET /projects
   # GET /projects.json
   def index
-    @projects = Project.all
+    @projects = Project.all.order(:sort)
   end
 
   # GET /projects/1
@@ -70,6 +70,6 @@ class ProjectsController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def project_params
-      params.require(:project).permit(:name, :about, :dev_date, :repo, :url, :status, :image)
+      params.require(:project).permit(:name, :about, :dev_date, :repo, :url, :status, :sort, :image)
     end
 end

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -36,6 +36,10 @@
     <%= f.text_area :status %>
   </div>
   <div class="field">
+    <%= f.label :sort %><br>
+    <%= f.text_field :sort %>
+  </div>
+  <div class="field">
     <%= f.label :image %><br>
     <%= f.text_field :image %>
   </div>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -29,6 +29,11 @@
   <%= @project.status %>
 </p>
 
+<p>
+  <strong>Sort</strong>
+  <%= @project.sort %>
+</p>
+
 <!-- only allow admins to see edit link -->
 <% if admin_signed_in? %>
   <%= link_to 'Edit', edit_project_path(@project) %> |

--- a/db/migrate/20150327180649_add_sort_column_to_projects.rb
+++ b/db/migrate/20150327180649_add_sort_column_to_projects.rb
@@ -1,0 +1,5 @@
+class AddSortColumnToProjects < ActiveRecord::Migration
+  def change
+    add_column :projects, :sort, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150323211919) do
+ActiveRecord::Schema.define(version: 20150327180649) do
 
   create_table "admins", force: :cascade do |t|
     t.string   "email",                  default: "", null: false
@@ -41,6 +41,7 @@ ActiveRecord::Schema.define(version: 20150323211919) do
     t.datetime "updated_at", null: false
     t.string   "image"
     t.string   "url"
+    t.integer  "sort"
   end
 
 end


### PR DESCRIPTION
Allows the for the adding of a sort number to a project. This allows the order of projects as displayed on the index page to be determined. Prior to this, a project could move from its current position if edited.
